### PR TITLE
Update for Buster, Alpine 3.10, and Python/PyPy upstream changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ services: docker
 matrix:
   include:
     - os: linux
+      env: TAG=python3.7-buster
+    - os: linux
       env: TAG=python3.7-stretch
     - os: linux
       env: TAG=python3.7-alpine3.10
@@ -13,28 +15,25 @@ matrix:
       dist: 1803-containers
       env: TAG=python3.7-windowsservercore-1803
     - os: linux
-      env: TAG=python3.6-stretch
+      env: TAG=python3.6-buster
     - os: linux
-      env: TAG=python3.6-jessie
+      env: TAG=python3.6-stretch
     - os: linux
       env: TAG=python3.6-alpine3.10
     - os: linux
       env: TAG=python3.6-alpine3.9
-    - os: windows
-      dist: 1803-containers
-      env: TAG=python3.6-windowsservercore-1803
+    - os: linux
+      env: TAG=python3.5-buster
     - os: linux
       env: TAG=python3.5-stretch
-    - os: linux
-      env: TAG=python3.5-jessie
     - os: linux
       env: TAG=python3.5-alpine3.10
     - os: linux
       env: TAG=python3.5-alpine3.9
     - os: linux
-      env: TAG=python2.7-stretch
+      env: TAG=python2.7-buster
     - os: linux
-      env: TAG=python2.7-jessie
+      env: TAG=python2.7-stretch
     - os: linux
       env: TAG=python2.7-alpine3.10
     - os: linux
@@ -44,8 +43,6 @@ matrix:
       env: TAG=python2.7-windowsservercore-1803
     - os: linux
       env: TAG=pypy3.6-stretch
-    - os: linux
-      env: TAG=pypy3.5-stretch
     - os: linux
       env: TAG=pypy2.7-jessie
 

--- a/dockerfiles-generated/Dockerfile.pypy3.5-stretch
+++ b/dockerfiles-generated/Dockerfile.pypy3.5-stretch
@@ -1,7 +1,0 @@
-FROM pypy:3.5-slim-stretch
-
-ENV HY_VERSION 0.17.0
-
-RUN pip install --no-cache-dir "hy == $HY_VERSION"
-
-CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python2.7-jessie
+++ b/dockerfiles-generated/Dockerfile.python2.7-jessie
@@ -1,7 +1,0 @@
-FROM python:2.7-slim-jessie
-
-ENV HY_VERSION 0.17.0
-
-RUN pip install --no-cache-dir "hy == $HY_VERSION"
-
-CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python3.5-jessie
+++ b/dockerfiles-generated/Dockerfile.python3.5-jessie
@@ -1,7 +1,0 @@
-FROM python:3.5-slim-jessie
-
-ENV HY_VERSION 0.17.0
-
-RUN pip install --no-cache-dir "hy == $HY_VERSION"
-
-CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python3.6-jessie
+++ b/dockerfiles-generated/Dockerfile.python3.6-jessie
@@ -1,7 +1,0 @@
-FROM python:3.6-slim-jessie
-
-ENV HY_VERSION 0.17.0
-
-RUN pip install --no-cache-dir "hy == $HY_VERSION"
-
-CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python3.6-windowsservercore-1803
+++ b/dockerfiles-generated/Dockerfile.python3.6-windowsservercore-1803
@@ -1,7 +1,0 @@
-FROM python:3.6-windowsservercore-1803
-
-ENV HY_VERSION 0.17.0
-
-RUN pip install --no-cache-dir ('hy == {0}' -f $env:HY_VERSION)
-
-CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python3.6-windowsservercore-1809
+++ b/dockerfiles-generated/Dockerfile.python3.6-windowsservercore-1809
@@ -1,7 +1,0 @@
-FROM python:3.6-windowsservercore-1809
-
-ENV HY_VERSION 0.17.0
-
-RUN pip install --no-cache-dir ('hy == {0}' -f $env:HY_VERSION)
-
-CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python3.6-windowsservercore-ltsc2016
+++ b/dockerfiles-generated/Dockerfile.python3.6-windowsservercore-ltsc2016
@@ -1,7 +1,0 @@
-FROM python:3.6-windowsservercore-ltsc2016
-
-ENV HY_VERSION 0.17.0
-
-RUN pip install --no-cache-dir ('hy == {0}' -f $env:HY_VERSION)
-
-CMD ["hy"]

--- a/dockerfiles-generated/library-hylang.template
+++ b/dockerfiles-generated/library-hylang.template
@@ -3,16 +3,20 @@ GitRepo: https://github.com/hylang/docker-hylang.git
 GitCommit: %%COMMIT%%
 Directory: dockerfiles-generated
 
-Tags: 0.17.0-python3.7-stretch, 0.17-python3.7-stretch, 0-python3.7-stretch, python3.7-stretch, 0.17.0-stretch, 0.17-stretch, 0-stretch, stretch
+Tags: 0.17.0-python3.7-buster, 0.17-python3.7-buster, 0-python3.7-buster, python3.7-buster, 0.17.0-buster, 0.17-buster, 0-buster, buster
 SharedTags: 0.17.0-python3.7, 0.17-python3.7, 0-python3.7, python3.7, 0.17.0, 0.17, 0, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python3.7-buster
+
+Tags: 0.17.0-python3.7-stretch, 0.17-python3.7-stretch, 0-python3.7-stretch, python3.7-stretch, 0.17.0-stretch, 0.17-stretch, 0-stretch, stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-stretch
 
-Tags: 0.17.0-python3.7-alpine3.10, 0.17-python3.7-alpine3.10, 0-python3.7-alpine3.10, python3.7-alpine3.10, 0.17.0-alpine3.10, 0.17-alpine3.10, 0-alpine3.10, alpine3.10
+Tags: 0.17.0-python3.7-alpine3.10, 0.17-python3.7-alpine3.10, 0-python3.7-alpine3.10, python3.7-alpine3.10, 0.17.0-alpine3.10, 0.17-alpine3.10, 0-alpine3.10, alpine3.10, 0.17.0-python3.7-alpine, 0.17-python3.7-alpine, 0-python3.7-alpine, python3.7-alpine, 0.17.0-alpine, 0.17-alpine, 0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.10
 
-Tags: 0.17.0-python3.7-alpine3.9, 0.17-python3.7-alpine3.9, 0-python3.7-alpine3.9, python3.7-alpine3.9, 0.17.0-alpine3.9, 0.17-alpine3.9, 0-alpine3.9, alpine3.9, 0.17.0-python3.7-alpine, 0.17-python3.7-alpine, 0-python3.7-alpine, python3.7-alpine, 0.17.0-alpine, 0.17-alpine, 0-alpine, alpine
+Tags: 0.17.0-python3.7-alpine3.9, 0.17-python3.7-alpine3.9, 0-python3.7-alpine3.9, python3.7-alpine3.9, 0.17.0-alpine3.9, 0.17-alpine3.9, 0-alpine3.9, alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.9
 
@@ -34,72 +38,54 @@ Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 File: Dockerfile.python3.7-windowsservercore-ltsc2016
 
-Tags: 0.17.0-python3.6-stretch, 0.17-python3.6-stretch, 0-python3.6-stretch, python3.6-stretch
+Tags: 0.17.0-python3.6-buster, 0.17-python3.6-buster, 0-python3.6-buster, python3.6-buster
 SharedTags: 0.17.0-python3.6, 0.17-python3.6, 0-python3.6, python3.6
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python3.6-buster
+
+Tags: 0.17.0-python3.6-stretch, 0.17-python3.6-stretch, 0-python3.6-stretch, python3.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-stretch
 
-Tags: 0.17.0-python3.6-jessie, 0.17-python3.6-jessie, 0-python3.6-jessie, python3.6-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-File: Dockerfile.python3.6-jessie
-
-Tags: 0.17.0-python3.6-alpine3.10, 0.17-python3.6-alpine3.10, 0-python3.6-alpine3.10, python3.6-alpine3.10
+Tags: 0.17.0-python3.6-alpine3.10, 0.17-python3.6-alpine3.10, 0-python3.6-alpine3.10, python3.6-alpine3.10, 0.17.0-python3.6-alpine, 0.17-python3.6-alpine, 0-python3.6-alpine, python3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-alpine3.10
 
-Tags: 0.17.0-python3.6-alpine3.9, 0.17-python3.6-alpine3.9, 0-python3.6-alpine3.9, python3.6-alpine3.9, 0.17.0-python3.6-alpine, 0.17-python3.6-alpine, 0-python3.6-alpine, python3.6-alpine
+Tags: 0.17.0-python3.6-alpine3.9, 0.17-python3.6-alpine3.9, 0-python3.6-alpine3.9, python3.6-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.6-alpine3.9
 
-Tags: 0.17.0-python3.6-windowsservercore-1809, 0.17-python3.6-windowsservercore-1809, 0-python3.6-windowsservercore-1809, python3.6-windowsservercore-1809
-SharedTags: 0.17.0-python3.6, 0.17-python3.6, 0-python3.6, python3.6
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-File: Dockerfile.python3.6-windowsservercore-1809
-
-Tags: 0.17.0-python3.6-windowsservercore-1803, 0.17-python3.6-windowsservercore-1803, 0-python3.6-windowsservercore-1803, python3.6-windowsservercore-1803
-SharedTags: 0.17.0-python3.6, 0.17-python3.6, 0-python3.6, python3.6
-Architectures: windows-amd64
-Constraints: windowsservercore-1803
-File: Dockerfile.python3.6-windowsservercore-1803
-
-Tags: 0.17.0-python3.6-windowsservercore-ltsc2016, 0.17-python3.6-windowsservercore-ltsc2016, 0-python3.6-windowsservercore-ltsc2016, python3.6-windowsservercore-ltsc2016
-SharedTags: 0.17.0-python3.6, 0.17-python3.6, 0-python3.6, python3.6
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2016
-File: Dockerfile.python3.6-windowsservercore-ltsc2016
+Tags: 0.17.0-python3.5-buster, 0.17-python3.5-buster, 0-python3.5-buster, python3.5-buster
+SharedTags: 0.17.0-python3.5, 0.17-python3.5, 0-python3.5, python3.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python3.5-buster
 
 Tags: 0.17.0-python3.5-stretch, 0.17-python3.5-stretch, 0-python3.5-stretch, python3.5-stretch
-SharedTags: 0.17.0-python3.5, 0.17-python3.5, 0-python3.5, python3.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-stretch
 
-Tags: 0.17.0-python3.5-jessie, 0.17-python3.5-jessie, 0-python3.5-jessie, python3.5-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-File: Dockerfile.python3.5-jessie
-
-Tags: 0.17.0-python3.5-alpine3.10, 0.17-python3.5-alpine3.10, 0-python3.5-alpine3.10, python3.5-alpine3.10
+Tags: 0.17.0-python3.5-alpine3.10, 0.17-python3.5-alpine3.10, 0-python3.5-alpine3.10, python3.5-alpine3.10, 0.17.0-python3.5-alpine, 0.17-python3.5-alpine, 0-python3.5-alpine, python3.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-alpine3.10
 
-Tags: 0.17.0-python3.5-alpine3.9, 0.17-python3.5-alpine3.9, 0-python3.5-alpine3.9, python3.5-alpine3.9, 0.17.0-python3.5-alpine, 0.17-python3.5-alpine, 0-python3.5-alpine, python3.5-alpine
+Tags: 0.17.0-python3.5-alpine3.9, 0.17-python3.5-alpine3.9, 0-python3.5-alpine3.9, python3.5-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.5-alpine3.9
 
-Tags: 0.17.0-python2.7-stretch, 0.17-python2.7-stretch, 0-python2.7-stretch, python2.7-stretch
+Tags: 0.17.0-python2.7-buster, 0.17-python2.7-buster, 0-python2.7-buster, python2.7-buster
 SharedTags: 0.17.0-python2.7, 0.17-python2.7, 0-python2.7, python2.7
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+File: Dockerfile.python2.7-buster
+
+Tags: 0.17.0-python2.7-stretch, 0.17-python2.7-stretch, 0-python2.7-stretch, python2.7-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-stretch
 
-Tags: 0.17.0-python2.7-jessie, 0.17-python2.7-jessie, 0-python2.7-jessie, python2.7-jessie
-Architectures: amd64, arm32v5, arm32v7, i386
-File: Dockerfile.python2.7-jessie
-
-Tags: 0.17.0-python2.7-alpine3.10, 0.17-python2.7-alpine3.10, 0-python2.7-alpine3.10, python2.7-alpine3.10
+Tags: 0.17.0-python2.7-alpine3.10, 0.17-python2.7-alpine3.10, 0-python2.7-alpine3.10, python2.7-alpine3.10, 0.17.0-python2.7-alpine, 0.17-python2.7-alpine, 0-python2.7-alpine, python2.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-alpine3.10
 
-Tags: 0.17.0-python2.7-alpine3.9, 0.17-python2.7-alpine3.9, 0-python2.7-alpine3.9, python2.7-alpine3.9, 0.17.0-python2.7-alpine, 0.17-python2.7-alpine, 0-python2.7-alpine, python2.7-alpine
+Tags: 0.17.0-python2.7-alpine3.9, 0.17-python2.7-alpine3.9, 0-python2.7-alpine3.9, python2.7-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python2.7-alpine3.9
 
@@ -122,14 +108,8 @@ Constraints: windowsservercore-ltsc2016
 File: Dockerfile.python2.7-windowsservercore-ltsc2016
 
 Tags: 0.17.0-pypy3.6-stretch, 0.17-pypy3.6-stretch, 0-pypy3.6-stretch, pypy3.6-stretch, 0.17.0-pypy-stretch, 0.17-pypy-stretch, 0-pypy-stretch, pypy-stretch
-SharedTags: 0.17.0-pypy3.6, 0.17-pypy3.6, 0-pypy3.6, pypy3.6, 0.17.0-pypy, 0.17-pypy, 0-pypy, pypy
-Architectures: amd64, i386, s390x
+Architectures: amd64, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.pypy3.6-stretch
-
-Tags: 0.17.0-pypy3.5-stretch, 0.17-pypy3.5-stretch, 0-pypy3.5-stretch, pypy3.5-stretch
-SharedTags: 0.17.0-pypy3.5, 0.17-pypy3.5, 0-pypy3.5, pypy3.5
-Architectures: amd64, i386, ppc64le, s390x
-File: Dockerfile.pypy3.5-stretch
 
 Tags: 0.17.0-pypy2.7-jessie, 0.17-pypy2.7-jessie, 0-pypy2.7-jessie, pypy2.7-jessie
 Architectures: amd64, i386

--- a/update.sh
+++ b/update.sh
@@ -22,10 +22,10 @@ variants=(
 	windowsservercore-1809 windowsservercore-1803 windowsservercore-ltsc2016
 )
 declare -A variantAliases=(
-	[alpine3.9]='alpine'
+	[alpine3.10]='alpine'
 )
 declare -A sharedTags=(
-	[stretch]='latest'
+	[buster]='latest'
 )
 for variant in "${variants[@]}"; do if [[ "$variant" == windowsservercore-* ]]; then sharedTags[$variant]='latest'; fi; done
 


### PR DESCRIPTION
This also skips Python 3.8 (hopefully temporarily) because 3.8 isn't actually supported properly by the Hy 0.17.0 release.

Here's the temporary local patch I used to generate this sans Python 3.8 (which immediately fails even basic tests like running the REPL at all):

```diff
diff --git a/update.sh b/update.sh
index 5d54e9e..0afc6b7 100755
--- a/update.sh
+++ b/update.sh
@@ -12,6 +12,9 @@ pythonVersions="$(
                | sort -rV
 )"
 
+# TODO Hy 0.17.0 doesn't support Python 3.8; we need something a tad newer :(
+pythonVersions="$(grep -vE '^3[.]8$' <<<"$pythonVersions")"
+
 bases=(
        python
        pypy
```