### PR TITLE
Add Windows Server 2025 variant

### DIFF
--- a/dockerfiles-generated/Dockerfile.pypy3.10-windowsservercore-ltsc2025
+++ b/dockerfiles-generated/Dockerfile.pypy3.10-windowsservercore-ltsc2025
@@ -1,0 +1,8 @@
+FROM pypy:3.10-windowsservercore-ltsc2025
+
+ENV HY_VERSION 1.0.0
+ENV HYRULE_VERSION 0.8.0
+
+RUN pip install --no-cache-dir ('hy == {0}' -f $env:HY_VERSION) ('hyrule == {0}' -f $env:HYRULE_VERSION)
+
+CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python3.12-windowsservercore-ltsc2025
+++ b/dockerfiles-generated/Dockerfile.python3.12-windowsservercore-ltsc2025
@@ -1,0 +1,8 @@
+FROM python:3.12-windowsservercore-ltsc2025
+
+ENV HY_VERSION 1.0.0
+ENV HYRULE_VERSION 0.8.0
+
+RUN pip install --no-cache-dir ('hy == {0}' -f $env:HY_VERSION) ('hyrule == {0}' -f $env:HYRULE_VERSION)
+
+CMD ["hy"]

--- a/dockerfiles-generated/Dockerfile.python3.13-windowsservercore-ltsc2025
+++ b/dockerfiles-generated/Dockerfile.python3.13-windowsservercore-ltsc2025
@@ -1,0 +1,8 @@
+FROM python:3.13-windowsservercore-ltsc2025
+
+ENV HY_VERSION 1.0.0
+ENV HYRULE_VERSION 0.8.0
+
+RUN pip install --no-cache-dir ('hy == {0}' -f $env:HY_VERSION) ('hyrule == {0}' -f $env:HYRULE_VERSION)
+
+CMD ["hy"]

--- a/dockerfiles-generated/library-hylang.template
+++ b/dockerfiles-generated/library-hylang.template
@@ -20,6 +20,12 @@ Tags: 1.0.0-python3.13-alpine3.20, 1.0-python3.13-alpine3.20, 1-python3.13-alpin
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.13-alpine3.20
 
+Tags: 1.0.0-python3.13-windowsservercore-ltsc2025, 1.0-python3.13-windowsservercore-ltsc2025, 1-python3.13-windowsservercore-ltsc2025, python3.13-windowsservercore-ltsc2025, 1.0.0-windowsservercore-ltsc2025, 1.0-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 1.0.0-python3.13, 1.0-python3.13, 1-python3.13, python3.13, 1.0.0, 1.0, 1, latest
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2025
+File: Dockerfile.python3.13-windowsservercore-ltsc2025
+
 Tags: 1.0.0-python3.13-windowsservercore-ltsc2022, 1.0-python3.13-windowsservercore-ltsc2022, 1-python3.13-windowsservercore-ltsc2022, python3.13-windowsservercore-ltsc2022, 1.0.0-windowsservercore-ltsc2022, 1.0-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 1.0.0-python3.13, 1.0-python3.13, 1-python3.13, python3.13, 1.0.0, 1.0, 1, latest
 Architectures: windows-amd64
@@ -48,6 +54,12 @@ File: Dockerfile.python3.12-alpine3.21
 Tags: 1.0.0-python3.12-alpine3.20, 1.0-python3.12-alpine3.20, 1-python3.12-alpine3.20, python3.12-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.12-alpine3.20
+
+Tags: 1.0.0-python3.12-windowsservercore-ltsc2025, 1.0-python3.12-windowsservercore-ltsc2025, 1-python3.12-windowsservercore-ltsc2025, python3.12-windowsservercore-ltsc2025
+SharedTags: 1.0.0-python3.12, 1.0-python3.12, 1-python3.12, python3.12
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2025
+File: Dockerfile.python3.12-windowsservercore-ltsc2025
 
 Tags: 1.0.0-python3.12-windowsservercore-ltsc2022, 1.0-python3.12-windowsservercore-ltsc2022, 1-python3.12-windowsservercore-ltsc2022, python3.12-windowsservercore-ltsc2022
 SharedTags: 1.0.0-python3.12, 1.0-python3.12, 1-python3.12, python3.12
@@ -120,6 +132,12 @@ File: Dockerfile.pypy3.10-bookworm
 Tags: 1.0.0-pypy3.10-bullseye, 1.0-pypy3.10-bullseye, 1-pypy3.10-bullseye, pypy3.10-bullseye, 1.0.0-pypy-bullseye, 1.0-pypy-bullseye, 1-pypy-bullseye, pypy-bullseye
 Architectures: amd64, arm64v8, i386
 File: Dockerfile.pypy3.10-bullseye
+
+Tags: 1.0.0-pypy3.10-windowsservercore-ltsc2025, 1.0-pypy3.10-windowsservercore-ltsc2025, 1-pypy3.10-windowsservercore-ltsc2025, pypy3.10-windowsservercore-ltsc2025, 1.0.0-pypy-windowsservercore-ltsc2025, 1.0-pypy-windowsservercore-ltsc2025, 1-pypy-windowsservercore-ltsc2025, pypy-windowsservercore-ltsc2025
+SharedTags: 1.0.0-pypy3.10, 1.0-pypy3.10, 1-pypy3.10, pypy3.10, 1.0.0-pypy, 1.0-pypy, 1-pypy, pypy
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2025
+File: Dockerfile.pypy3.10-windowsservercore-ltsc2025
 
 Tags: 1.0.0-pypy3.10-windowsservercore-ltsc2022, 1.0-pypy3.10-windowsservercore-ltsc2022, 1-pypy3.10-windowsservercore-ltsc2022, pypy3.10-windowsservercore-ltsc2022, 1.0.0-pypy-windowsservercore-ltsc2022, 1.0-pypy-windowsservercore-ltsc2022, 1-pypy-windowsservercore-ltsc2022, pypy-windowsservercore-ltsc2022
 SharedTags: 1.0.0-pypy3.10, 1.0-pypy3.10, 1-pypy3.10, pypy3.10, 1.0.0-pypy, 1.0-pypy, 1-pypy, pypy

--- a/update.sh
+++ b/update.sh
@@ -56,7 +56,7 @@ bases=(
 variants=(
 	bookworm bullseye
 	alpine3.21 alpine3.20
-	windowsservercore-ltsc2022 windowsservercore-1809
+	windowsservercore-ltsc2025 windowsservercore-ltsc2022 windowsservercore-1809
 )
 declare -A variantAliases=(
 	[alpine3.21]='alpine'


### PR DESCRIPTION
Add Windows Server ltsc2025. This will fail build tests until the `python:*-ltsc2025` and `pypy:*-ltsc2025` images are fully built and pushed (https://github.com/docker-library/official-images/pull/18289 https://github.com/docker-library/official-images/pull/18291)

Refs: https://github.com/docker-library/official-images/pull/18143

edit: and pypy